### PR TITLE
Bug: Require base farming mod to be loaded

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -7,6 +7,7 @@ fishing?
 glooptest?
 bushes?
 docfarming?
+farming?
 farming_plus?
 mtfoods?
 bushes_classic?


### PR DESCRIPTION
On my personal server I could not figure out why eating bread was not affecting the players hunger bar. Turns out that the farming mod was being loaded after the hud mod. By placing the dependency on the base farming mod in the depends.txt it seems to have fixed this issue and now eating bread on my servers reduces the players hunger as expected.
