### PR TITLE
Ferns, Farming Redo, Mobs Redo, Mushroom food

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -10,6 +10,7 @@ dwarves?
 ethereal?
 farming?
 farming_plus?
+ferns?
 fishing?
 fruit?
 glooptest?

--- a/hunger.lua
+++ b/hunger.lua
@@ -329,6 +329,14 @@ if minetest.get_modpath("cooking") ~= nil then
 	overwrite("cooking:meat_undead_cooked", 1)
 end
 
+-- ferns mod of plantlife_modpack
+if minetest.get_modpath("ferns") ~= nil then
+	overwrite("ferns:fiddlehead", 1, "", 1)
+	overwrite("ferns:fiddlehead_roasted", 3)
+	overwrite("ferns:ferntuber_roasted", 3)
+	overwrite("ferns:horsetail_01", 1)
+end
+
 -- player-action based hunger changes
 function hud.handle_node_actions(pos, oldnode, player, ext)
 	if not player or not player:is_player() then

--- a/hunger.lua
+++ b/hunger.lua
@@ -164,6 +164,11 @@ end
 if minetest.get_modpath("mushroom") ~= nil then
 	overwrite("mushroom:brown", 1)
 	overwrite("mushroom:red", 1, "", 3)
+	-- mushroom potions: red = strong poison, brown = light restorative
+	if minetest.get_modpath("vessels") then
+		overwrite("mushroom:brown_essence", 1, "vessels:glass_bottle", nil, 4)
+		overwrite("mushroom:poison", 1, "vessels:glass_bottle", 10)
+	end
 end
 
 if minetest.get_modpath("docfarming") ~= nil then

--- a/hunger.lua
+++ b/hunger.lua
@@ -66,9 +66,25 @@ if minetest.get_modpath("farming") ~= nil then
 end
 
 if minetest.get_modpath("mobs") ~= nil then
-	overwrite("mobs:meat", 6)
-	overwrite("mobs:meat_raw", 3)
-	overwrite("mobs:rat_cooked", 5)
+	if mobs.mod ~= nil and mobs.mod == "redo" then
+		overwrite("mobs:cheese", 4)
+		overwrite("mobs:meat", 8)
+		overwrite("mobs:meat_raw", 4)
+		overwrite("mobs:rat_cooked", 4)
+		overwrite("mobs:honey", 2)
+		overwrite("mobs:pork_raw", 3, "", 3)
+		overwrite("mobs:pork_cooked", 8)
+		overwrite("mobs:chicken_cooked", 6)
+		overwrite("mobs:chicken_raw", 2, "", 3)
+		overwrite("mobs:chicken_egg_fried", 2)
+		if minetest.get_modpath("bucket") then 
+			overwrite("mobs:bucket_milk", 3, "bucket:bucket_empty")
+		end
+	else
+		overwrite("mobs:meat", 6)
+		overwrite("mobs:meat_raw", 3)
+		overwrite("mobs:rat_cooked", 5)
+	end
 end
 
 if minetest.get_modpath("moretrees") ~= nil then
@@ -284,6 +300,8 @@ if minetest.get_modpath("farming") and farming.mod == "redo" then
    overwrite("farming:donut_chocolate", 6)
    overwrite("farming:donut_apple", 6)
    overwrite("farming:raspberries", 1)
+   overwrite("farming:blueberries", 1)
+   overwrite("farming:muffin_blueberry", 4)
    if minetest.get_modpath("vessels") then
 	overwrite("farming:smoothie_raspberry", 2, "vessels:drinking_glass")
    end


### PR DESCRIPTION
Hello. This code adds hunger support for the few edible things of Ferns (of plantlife_modpack) and updates Farming Redo (new blueberry plant) and Mobs Redo (which wasn't really supported yet). 

Mobs Redo and Farming redo hunger values come from TenPlus1, the one of the slightly poisonous plant of Ferns is guessed. 

Edit: Added the potions of mushroom (plantlife_modpack).
